### PR TITLE
feat: new method runWithRepository for overriding the global SRepository

### DIFF
--- a/api/src/main/kotlin/org/modelix/mps/api/ContextRepository.kt
+++ b/api/src/main/kotlin/org/modelix/mps/api/ContextRepository.kt
@@ -1,0 +1,19 @@
+package org.modelix.mps.api
+
+import org.jetbrains.mps.openapi.module.SRepository
+
+object ContextRepository {
+    private val threadLocal = ThreadLocal<SRepository>()
+
+    fun <R> runWith(repository: SRepository, body: () -> R): R {
+        val oldValue = threadLocal.get()
+        try {
+            threadLocal.set(repository)
+            return body()
+        } finally {
+            threadLocal.set(oldValue)
+        }
+    }
+
+    fun getRepository(): SRepository? = threadLocal.get()
+}

--- a/api/src/main/kotlin/org/modelix/mps/api/IModelixMpsApi.kt
+++ b/api/src/main/kotlin/org/modelix/mps/api/IModelixMpsApi.kt
@@ -11,7 +11,7 @@ import org.jetbrains.mps.openapi.project.Project
 import java.awt.Component
 
 interface IModelixMpsApi {
-    fun getRepository(): SRepository = getProjectRepository() ?: getGlobalRepository()
+    fun getRepository(): SRepository = ContextRepository.getRepository() ?: getProjectRepository() ?: getGlobalRepository()
     fun getGlobalRepository(): SRepository
     fun getProjectRepository(): SRepository?
     fun getRepository(project: Project): SRepository
@@ -40,4 +40,5 @@ interface IModelixMpsApi {
     fun <R> runWithProject(project: Project, body: () -> R): R =
         ContextProject.runWith(project, body)
     fun <R> runWithProject(project: com.intellij.openapi.project.Project, body: () -> R): R = runWithProject(getMPSProject(project), body)
+    fun <R> runWithRepository(repository: SRepository, body: () -> R): R = ContextRepository.runWith(repository, body)
 }

--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -18,6 +18,7 @@ public final class org/modelix/mps/api/ModelixMpsApi : org/modelix/mps/api/IMode
 	public fun getVirtualFolders (Lorg/jetbrains/mps/openapi/module/SModule;)Ljava/util/List;
 	public fun runWithProject (Lcom/intellij/openapi/project/Project;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public fun runWithProject (Lorg/jetbrains/mps/openapi/project/Project;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun runWithRepository (Lorg/jetbrains/mps/openapi/module/SRepository;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public fun setReference (Lorg/jetbrains/mps/openapi/model/SNode;Lorg/jetbrains/mps/openapi/language/SReferenceLink;Lorg/jetbrains/mps/openapi/model/SNodeReference;)V
 	public fun setVirtualFolder (Lorg/jetbrains/mps/openapi/module/SModule;Ljava/lang/String;)V
 	public fun setVirtualFolder (Lorg/jetbrains/mps/openapi/project/Project;Lorg/jetbrains/mps/openapi/module/SModule;Ljava/lang/String;)V


### PR DESCRIPTION
The Git import feature in modelix.core has its own SRepository implementation. It doesn't run inside a project and doesn't register modules in the global repository.