### PR TITLE
feat: add support for MPS 2025.1.2

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel>
+    <bytecodeTargetLevel target="11">
       <module name="modelix.mps-api.buildSrc" target="21" />
       <module name="modelix.mps-api.buildSrc.main" target="21" />
       <module name="modelix.mps-api.buildSrc.test" target="21" />

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -19,6 +19,7 @@
             <option value="$PROJECT_DIR$/impl233" />
             <option value="$PROJECT_DIR$/impl241" />
             <option value="$PROJECT_DIR$/impl243" />
+            <option value="$PROJECT_DIR$/impl251" />
             <option value="$PROJECT_DIR$/lib" />
           </set>
         </option>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.21" />
+    <option name="externalSystemId" value="Gradle" />
+    <option name="version" value="2.3.21" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,5 +4,5 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="temurin-21" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="temurin-21" project-jdk-type="JavaSDK" />
 </project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ val mpsVersions = mapOf<Int, String>(
     233 to "2023.3.2",
     241 to "2024.1.1",
     243 to "2024.3",
+    251 to "2025.1.2",
 )
 
 var previousMajorVersions_: List<Int> = emptyList()

--- a/impl251/src/main/kotlin/org/modelix/mps/api/ModelixMpsApiImpl251.kt
+++ b/impl251/src/main/kotlin/org/modelix/mps/api/ModelixMpsApiImpl251.kt
@@ -1,0 +1,3 @@
+package org.modelix.mps.api
+
+open class ModelixMpsApiImpl251 : ModelixMpsApiImpl243()

--- a/lib/src/main/kotlin/org/modelix/mps/api/ModelixMpsApi.kt
+++ b/lib/src/main/kotlin/org/modelix/mps/api/ModelixMpsApi.kt
@@ -28,6 +28,7 @@ private fun resolveInstance(): IModelixMpsApi {
         233 -> ModelixMpsApiImpl233()
         241 -> ModelixMpsApiImpl241()
         243 -> ModelixMpsApiImpl243()
+        251 -> ModelixMpsApiImpl251()
         else -> throw UnsupportedOperationException("Unsupported MPS version: $mpsVersion")
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,7 @@ val mpsVersions = mapOf<Int, String>(
     233 to "2023.3.2",
     241 to "2024.1.1",
     243 to "2024.3",
+    251 to "2025.1.2",
 )
 
 for (majorVersion in mpsVersions.keys) {


### PR DESCRIPTION
Adds support for MPS 2025.1.2 as major version `251`.

## Changes
- `build.gradle.kts` / `settings.gradle.kts`: add `251 to "2025.1.2"` to the `mpsVersions` map, which wires up the `com.jetbrains:mps:2025.1.2` dependency, distribution download, and the `impl251` module.
- `impl251/.../ModelixMpsApiImpl251.kt`: new impl class extending `ModelixMpsApiImpl243`, following the version-inheritance pattern (no overrides needed — source-compatible with 2024.3).
- `lib/.../ModelixMpsApi.kt`: add `251 -> ModelixMpsApiImpl251()` branch to the runtime version selector.

Runtime detection (`detectMpsVersion`) already maps a 2025.1 install to `251` via both the plugin-version path and the `ApplicationInfo` fallback, so no change was needed there.

## Verification
- Full `./gradlew build` passes, including `:lib:apiCheck` (binary compatibility validation).
- `impl251` compiles against the real `com.jetbrains:mps:2025.1.2` distribution.